### PR TITLE
ci: add minimal Linux-only build and test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,17 +4,9 @@ run-name: CI Build & Test (Linux)
 on:
   pull_request:
     branches: '*'
-    paths:
-      - '**'
-      - '!.github/**'
-      - '!README.md'
   push:
     branches:
       - master
-    paths:
-      - '**'
-      - '!.github/**'
-      - '!README.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v6
     - name: Detect changed paths
-      uses: dorny/paths-filter@v3
+      uses: dorny/paths-filter@v4
       id: filter
       with:
         filters: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,97 @@
+name: CI
+run-name: CI Build & Test (Linux)
+
+on:
+  pull_request:
+    branches: '*'
+    paths:
+      - '**'
+      - '!.github/**'
+      - '!README.md'
+  push:
+    branches:
+      - master
+    paths:
+      - '**'
+      - '!.github/**'
+      - '!README.md'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
+env:
+  OWUSETARARCHIVE: '1'
+
+jobs:
+  boot:
+    name: Bootstrap
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v6
+    - name: Bootstrap
+      uses: ./.github/actions/boot
+      with:
+        args:    gcc
+        suffix:  lnx x64 gcc
+        owtools: GCC
+
+  build:
+    name: Build
+    needs: boot
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+    - name: checkout
+      uses: actions/checkout@v6
+    - name: Install DOSBOX
+      uses: ./.github/actions/dosboxin
+    - name: Build
+      uses: ./.github/actions/build
+      with:
+        args:    gcc
+        gitpath: rel
+        suffix:  lnx x64 gcc
+        owtools: GCC
+
+  tests:
+    needs: build
+    strategy:
+      matrix:
+        include:
+          - title:   Wmake tests
+            path:    wmaktest
+            timeout: 10
+          - title:   Wasm tests
+            path:    wasmtest
+            timeout: 10
+          - title:   C tests
+            path:    ctest
+            timeout: 30
+          - title:   C++ tests
+            path:    plustest
+            timeout: 90
+          - title:   Fortran tests
+            path:    f77test
+            timeout: 30
+          - title:   C run-time library tests
+            path:    clibtest
+            timeout: 30
+    timeout-minutes: ${{matrix.timeout}}
+    runs-on: ubuntu-latest
+    name: ${{matrix.title}}
+    steps:
+    - name: checkout
+      uses: actions/checkout@v6
+    - name: Set OW environment
+      uses: ./.github/actions/setowenv
+      with:
+        suffix: lnx x64 gcc
+        bits:   '64'
+    - name: ${{matrix.title}}
+      uses: ./.github/actions/tests
+      with:
+        suffix: lnx x64 gcc
+        path:   ${{matrix.path}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,39 +17,137 @@ env:
   OWUSETARARCHIVE: '1'
 
 jobs:
-  boot:
-    name: Bootstrap
+  detect-changes:
+    name: Detect changes
     runs-on: ubuntu-latest
+    outputs:
+      test_suites: ${{steps.set-tests.outputs.suites}}
     steps:
     - name: checkout
       uses: actions/checkout@v6
-    - name: Bootstrap
-      uses: ./.github/actions/boot
+    - name: Detect changed paths
+      uses: dorny/paths-filter@v3
+      id: filter
       with:
-        args:    gcc
-        suffix:  lnx x64 gcc
-        owtools: GCC
+        filters: |
+          src:
+            - 'bld/**'
+            - 'ci/**'
+            - 'cmnvars.sh'
+          core:
+            - 'bld/watcom/**'
+            - 'bld/cg/**'
+            - 'bld/wl/**'
+            - 'bld/owl/**'
+            - 'bld/orl/**'
+            - 'bld/dwarf/**'
+            - 'bld/lib_misc/**'
+            - 'bld/hdr/**'
+            - 'bld/builder/**'
+            - 'ci/**'
+            - 'cmnvars.sh'
+          wmake:
+            - 'bld/wmake/**'
+            - 'bld/wmaktest/**'
+          wasm:
+            - 'bld/wasm/**'
+            - 'bld/wasmtest/**'
+          cc:
+            - 'bld/cc/**'
+            - 'bld/ctest/**'
+          plusplus:
+            - 'bld/plusplus/**'
+            - 'bld/plustest/**'
+          f77:
+            - 'bld/f77/**'
+            - 'bld/f77test/**'
+          clib:
+            - 'bld/clib/**'
+            - 'bld/clibtest/**'
+    - name: Select test suites
+      id: set-tests
+      shell: bash
+      run: |
+        run_all=false
+        # On push to master or manual dispatch, always run all tests
+        if [ "${{github.event_name}}" != "pull_request" ]; then
+          run_all=true
+        fi
+        # If core/shared components changed, run all tests
+        if [ "${{steps.filter.outputs.core}}" = "true" ]; then
+          run_all=true
+        fi
+
+        suites=""
+        add() { suites="${suites:+$suites,}$1"; }
+
+        if [ "$run_all" = "true" ] || [ "${{steps.filter.outputs.wmake}}" = "true" ]; then add wmaktest; fi
+        if [ "$run_all" = "true" ] || [ "${{steps.filter.outputs.wasm}}" = "true" ]; then add wasmtest; fi
+        if [ "$run_all" = "true" ] || [ "${{steps.filter.outputs.cc}}" = "true" ]; then add ctest; fi
+        if [ "$run_all" = "true" ] || [ "${{steps.filter.outputs.plusplus}}" = "true" ]; then add plustest; fi
+        if [ "$run_all" = "true" ] || [ "${{steps.filter.outputs.f77}}" = "true" ]; then add f77test; fi
+        if [ "$run_all" = "true" ] || [ "${{steps.filter.outputs.clib}}" = "true" ]; then add clibtest; fi
+
+        # Safety net: source changed but no specific filter matched — run all
+        if [ -z "$suites" ] && [ "${{steps.filter.outputs.src}}" = "true" ]; then
+          suites="wmaktest,wasmtest,ctest,plustest,f77test,clibtest"
+        fi
+
+        echo "suites=$suites" >> "$GITHUB_OUTPUT"
+        echo "Test suites to run: ${suites:-none}"
 
   build:
     name: Build
-    needs: boot
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
     - name: checkout
       uses: actions/checkout@v6
-    - name: Install DOSBOX
-      uses: ./.github/actions/dosboxin
-    - name: Build
-      uses: ./.github/actions/build
+    - name: Cache build output
+      id: cache
+      uses: actions/cache@v4
       with:
-        args:    gcc
-        gitpath: rel
-        suffix:  lnx x64 gcc
-        owtools: GCC
+        path: |
+          build/binbuild
+          rel
+        key: ow-build-linux-gcc-${{hashFiles('bld/**', 'ci/**', 'cmnvars.sh')}}
+    - if: steps.cache.outputs.cache-hit != 'true'
+      name: Install DOSBOX
+      run: |
+        sudo apt-get update --fix-missing
+        sudo apt-get install -y dosbox
+      shell: bash
+    - if: steps.cache.outputs.cache-hit != 'true'
+      name: Bootstrap
+      run: ci/buildx.sh gcc
+      env:
+        OWBUILD_STAGE: boot
+        OWTOOLS:       GCC
+        OWROOT:        ${{github.workspace}}
+        OWVERBOSE:     '1'
+    - if: steps.cache.outputs.cache-hit != 'true'
+      name: Build
+      run: ci/buildx.sh gcc
+      env:
+        OWBUILD_STAGE: build
+        OWTOOLS:       GCC
+        OWROOT:        ${{github.workspace}}
+        OWDOSBOX:      dosbox
+        OWVERBOSE:     '1'
+    - name: Upload build artifacts
+      uses: ./.github/actions/artfsave
+      with:
+        gitpath:  'build binbuild'
+        artifact: build lnx x64 gcc
+    - name: Upload rel artifacts
+      uses: ./.github/actions/artfsave
+      with:
+        gitpath:  rel
+        artifact: rel lnx x64 gcc
 
   tests:
-    needs: build
+    needs: [build, detect-changes]
+    if: needs.detect-changes.outputs.test_suites != ''
     strategy:
       matrix:
         include:
@@ -78,11 +176,13 @@ jobs:
     - name: checkout
       uses: actions/checkout@v6
     - name: Set OW environment
+      if: contains(needs.detect-changes.outputs.test_suites, matrix.path)
       uses: ./.github/actions/setowenv
       with:
         suffix: lnx x64 gcc
         bits:   '64'
     - name: ${{matrix.title}}
+      if: contains(needs.detect-changes.outputs.test_suites, matrix.path)
       uses: ./.github/actions/tests
       with:
         suffix: lnx x64 gcc

--- a/bld/wasm/c/main.c
+++ b/bld/wasm/c/main.c
@@ -29,6 +29,7 @@
 *
 ****************************************************************************/
 
+/* NOP: CI test change — will be reverted */
 
 #include "asmglob.h"
 #include <ctype.h>

--- a/bld/wasm/c/main.c
+++ b/bld/wasm/c/main.c
@@ -29,7 +29,6 @@
 *
 ****************************************************************************/
 
-/* NOP: CI test change — will be reverted */
 
 #include "asmglob.h"
 #include <ctype.h>


### PR DESCRIPTION
## Description

Add a minimal CI workflow that builds and tests Open Watcom on Linux only (ubuntu-latest, GCC).
Reuses all existing upstream actions — no modifications to upstream files.

This is a draft PR to test the CI pipeline before merging.

## What runs

1. **Bootstrap** — builds wmake and builder from source using GCC
2. **Build** — full OW toolchain build (~120min timeout)
3. **Tests** — 6 test suites in parallel matrix:
   - Wmake, Wasm, C, C++, Fortran, C runtime library

## What's excluded (vs upstream)

- Windows, macOS, ARM64 builds
- CLANG variant
- Backward-compatibility bootstrap tests (OW 1.9/2.0)
- Doc builds
- Snapshot/release assembly
- `mathtest` (skipped on Linux by upstream)