### PR TITLE
wdis: fix crash on small data sections in source listing mode

### DIFF
--- a/bld/ndisasm/stand/c/formasm.c
+++ b/bld/ndisasm/stand/c/formasm.c
@@ -224,7 +224,7 @@ static size_t tryDUP( unsigned_8 *bytes, size_t i, size_t size )
     unsigned_64 value;
 
 
-    if( i >= ( size - ( 8 * MIN_DUP_LINES ) ) )
+    if( size < ( 8 * MIN_DUP_LINES ) || i >= ( size - ( 8 * MIN_DUP_LINES ) ) )
         return( 0 );
 
     for( d = i + 8; d < ( size - 8 ); d += 8 ) {

--- a/bld/wasmtest/test1/makefile
+++ b/bld/wasmtest/test1/makefile
@@ -80,6 +80,7 @@ shell.dis &
 size.dis &
 sizebug.dis &
 sizlen.dis &
+smalldat.dis &
 stos.dis &
 strmang.dis &
 struct.dis &

--- a/bld/wasmtest/test1/smalldat.asm
+++ b/bld/wasmtest/test1/smalldat.asm
@@ -1,0 +1,10 @@
+; Test: wdis -a must not crash on small data-in-code sections.
+; A single DB before code produces a 1-byte data region that
+; triggered an unsigned underflow in tryDUP(), crashing wdis.
+;
+.8086
+_TEXT SEGMENT BYTE PUBLIC 'CODE'
+my_var DB 0
+    mov al, my_var
+_TEXT ENDS
+END

--- a/bld/wasmtest/test1/smalldat.esm
+++ b/bld/wasmtest/test1/smalldat.esm
@@ -1,0 +1,8 @@
+.387
+_TEXT		SEGMENT	BYTE PUBLIC USE16 'CODE'
+		ASSUME CS:_TEXT, DS:DGROUP, SS:DGROUP
+L$1:
+    DB	0
+	mov		al,byte ptr cs:L$1
+_TEXT		ENDS
+		END


### PR DESCRIPTION
## Summary

`wdis -a` crashes when disassembling OMF objects that contain small data-in-code sections (fewer than 40 bytes). The `tryDUP()` function in `formasm.c` has an unsigned underflow: `size - (8 * MIN_DUP_LINES)` wraps around when `size < 40`, bypassing the guard and causing an out-of-bounds `memcmp` read.

## Reproduction

Any OMF object with a code segment containing a small data region (e.g. a single `DB 0` before instructions) triggers the crash when disassembled with `wdis -a`.

## Fix

Add `size < (8 * MIN_DUP_LINES)` guard before the unsigned subtraction.