### PR TITLE
wdis: remove 8 * MIN_DUP_LINES hack from tryDUP

### DIFF
--- a/bld/ndisasm/stand/c/formasm.c
+++ b/bld/ndisasm/stand/c/formasm.c
@@ -224,7 +224,7 @@ static size_t tryDUP( unsigned_8 *bytes, size_t i, size_t size )
     unsigned_64 value;
 
 
-    if( size < ( 8 * MIN_DUP_LINES ) || i >= ( size - ( 8 * MIN_DUP_LINES ) ) )
+    if( size - i < 8 )
         return( 0 );
 
     for( d = i + 8; d < ( size - 8 ); d += 8 ) {


### PR DESCRIPTION
Follow-up to open-watcom/open-watcom-v2#1599 per [reviewer feedback](https://github.com/open-watcom/open-watcom-v2/pull/1599#issuecomment-4213952433).

## Description

Replace the ad-hoc `8 * MIN_DUP_LINES` guard in `tryDUP()` with a minimal `size - i < 8` check. The existing `dup < MIN_DUP_LINES` condition already filters out insufficient repetitions naturally, so the larger threshold was unnecessary and was the root cause of the unsigned underflow on small data sections.

## Changes

* Simplified the early-exit guard in `tryDUP()` to only check for at least one 8-byte chunk, removing the `8 * MIN_DUP_LINES` hack entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)