### PR TITLE
wasm: fix crash in NAME directive when operand is missing

### DIFF
--- a/bld/wasm/c/direct.c
+++ b/bld/wasm/c/direct.c
@@ -4143,6 +4143,10 @@ bool NameDirective( token_buffer *tokbuf, token_idx i )
 /*****************************************************/
 {
     if( Options.module_name == NULL ) {
+        if( tokbuf->tokens[i + 1].class == TC_FINAL ) {
+            AsmError( OPERAND_EXPECTED );
+            return( RC_ERROR );
+        }
         Options.module_name = MemStrdupSafe( tokbuf->tokens[i + 1].string_ptr );
         ConvertModuleName( Options.module_name );
     }

--- a/bld/wasmtest/diag/makefile
+++ b/bld/wasmtest/diag/makefile
@@ -30,6 +30,7 @@ error1.dum &
 extern1.dum &
 include.dum &
 irp.dum &
+namedir.dum &
 cpureq.dum &
 ctrlzeof.dum
 

--- a/bld/wasmtest/diag/namedir.asm
+++ b/bld/wasmtest/diag/namedir.asm
@@ -1,0 +1,7 @@
+; Test: NAME directive without operand must produce E066,
+; not crash.  The label+directive heuristic rewrites
+; "call name" into label "call" + directive NAME with
+; no operand, which used to dereference a NULL pointer.
+;
+call name
+END

--- a/bld/wasmtest/diag/namedir.chk
+++ b/bld/wasmtest/diag/namedir.chk
@@ -1,0 +1,1 @@
+namedir.asm(6): Error! E066: Operand is expected


### PR DESCRIPTION
## Summary

Fix a SIGSEGV in `NameDirective()` when the NAME directive is reached without an operand.

`NameDirective()` reads `tokens[i+1].string_ptr` without checking whether the next token exists. When NAME is reached with no operand (e.g. via the label+directive heuristic rewriting `call name` into label `call` + directive NAME), `tokens[i+1]` is the TC_FINAL sentinel whose `string_ptr` is NULL. This NULL propagates through `MemStrdupSafe` → `ConvertModuleName`, which dereferences it → SIGSEGV.

### Reproducer

```asm
call name
END
```

```
$ wasm -zcm=masm test.asm
test.asm(1): Error! E066: Operand is expected   <-- with fix
Segmentation fault                               <-- without fix
```

### Fix

Add a `TC_FINAL` guard before accessing the token, matching the pattern used by other directive handlers in `direct.c`.