### PR TITLE
[codex] Fix wasm struct label initialization

### DIFF
--- a/bld/wasm/c/asmstruc.c
+++ b/bld/wasm/c/asmstruc.c
@@ -166,6 +166,13 @@ bool InitializeStructure( asm_sym_handle sym, asm_sym_handle struct_symbol, toke
         /* put the lines to define the fields of the structure in,
          * using the values specified ( if any ) or the default ones otherwise
          */
+        if( f->initializer == NULL ) {
+            /*
+             * LABEL members in structures define an offset alias only; they do
+             * not emit data and must not consume a structure initializer.
+             */
+            continue;
+        }
         len = strlen( f->initializer );
         p = CATSTR( buffer, f->initializer, len );
         *p++ = ' ' ;

--- a/bld/wasmtest/diag/makefile
+++ b/bld/wasmtest/diag/makefile
@@ -32,7 +32,8 @@ include.dum &
 irp.dum &
 namedir.dum &
 cpureq.dum &
-ctrlzeof.dum
+ctrlzeof.dum &
+structlb.dum
 
 asm_flags_diag01 = -4s
 asm_flags_diag02 = -3

--- a/bld/wasmtest/diag/structlb.asm
+++ b/bld/wasmtest/diag/structlb.asm
@@ -1,0 +1,13 @@
+.model tiny
+
+.code
+
+S STRUC
+    first   db      ?
+    marker  label   byte
+    second  dw      ?
+S ENDS
+
+anon    S       <1,2>
+
+end


### PR DESCRIPTION
## Summary

Fixes a wasm crash when expanding a structure initializer for a structure that contains a `LABEL` member.

`LABEL` members inside structures create an offset alias and do not emit data. They can therefore have no initializer text in the structure field list. `InitializeStructure()` previously assumed every field had initializer text and called `strlen()` unconditionally, which dereferenced null for these label-only fields.

This change skips label-only fields during structure initializer expansion, preserving their offset symbol while avoiding both data emission and initializer consumption.

## Regression Test

Adds `bld/wasmtest/diag/structlb.asm`, a minimal structure with a `label byte` member and an initializer that previously crashed wasm.

## Validation

Ran locally:

```sh
. ./setvars.sh >/tmp/ow-setvars.log && cd bld/wasmtest/diag && rm -f structlb.obj structlb.out PASS && wmake -h buildtest=1 arch=386 structlb.dum
```

The focused diagnostic target passes.
